### PR TITLE
Feature/podcast pubdate older

### DIFF
--- a/php/index.php
+++ b/php/index.php
@@ -133,13 +133,15 @@ function buildRssFeed(array $tracks, string $playlistTitle, string $playlistId):
     // Proxy mode: each track is a separate episode
     $totalTracks = count($tracks);
     $episode = 1;
+    // Calculate playlist offset: each playlist gets its own month offset based on playlist ID
+    $playlistOffset = (int)$playlistId % 120; // Modulo by 120 months (10 years) to avoid going too far back
     foreach ($tracks as $t) {
         $item = $dom->createElement('item');
         $item->appendChild($dom->createElement('title', htmlspecialchars($t['title'])));
         $guid = $dom->createElement('guid', $playlistId.'-'.$episode);
         $guid->setAttribute('isPermaLink', 'false');
         $item->appendChild($guid);
-        $item->appendChild($dom->createElement('pubDate', date('r', strtotime("-{$episode} minutes -10 years"))));
+        $item->appendChild($dom->createElement('pubDate', date('r', strtotime("-{$episode} minutes -10 years -{$playlistOffset} months"))));
         $item->appendChild($dom->createElement('itunes:episode', $totalTracks - $episode + 1));
         $item->appendChild($dom->createElement('itunes:season', 1));
         $enc = $dom->createElement('enclosure');

--- a/php/index.php
+++ b/php/index.php
@@ -139,7 +139,7 @@ function buildRssFeed(array $tracks, string $playlistTitle, string $playlistId):
         $guid = $dom->createElement('guid', $playlistId.'-'.$episode);
         $guid->setAttribute('isPermaLink', 'false');
         $item->appendChild($guid);
-        $item->appendChild($dom->createElement('pubDate', date('r', strtotime("-{$episode} minutes"))));
+        $item->appendChild($dom->createElement('pubDate', date('r', strtotime("-{$episode} minutes -10 years"))));
         $item->appendChild($dom->createElement('itunes:episode', $totalTracks - $episode + 1));
         $item->appendChild($dom->createElement('itunes:season', 1));
         $enc = $dom->createElement('enclosure');


### PR DESCRIPTION
# UI: Set podcast publish dates to 10 years ago with per-playlist month separation

## Problem
Episodes appeared at the top of "recent", making the feed hard to browse.

## Solution
Set all publish dates to 10 years ago and add a per-playlist month offset to separate playlists while keeping episodes grouped.

**Changes:**
- Publish dates set to 10 years ago
- Month offset per playlist by ID
- Modulo 120 to spread playlists across ~10 years
- Episodes within a playlist stay grouped
